### PR TITLE
Configure remote deployment settings

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 GUILD_DB_URL=postgres://nestuser:nestpass@postgres:5432/authdb?sslmode=disable
 JWT_SECRET=verysecret
-REALM=localhost
+REALM=77.110.98.32
 TURN_SECRET=local_dev_password
 EXTERNAL_IP=77.110.98.32

--- a/chat-service/main.go
+++ b/chat-service/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"log"
 	"os"
+	"strings"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
@@ -15,29 +16,33 @@ import (
 )
 
 func main() {
-    // Инициализируем Cassandra
-    repository.InitCassandra()
+	// Инициализируем Cassandra
+	repository.InitCassandra()
 
-    // Создаём хаб WS
-    hub := ws.NewHub()
+	// Создаём хаб WS
+	hub := ws.NewHub()
 
-    // Запускаем Gin
-    r := gin.Default()
-  r.Use(cors.New(cors.Config{
-    AllowOrigins:     []string{"http://localhost:3001"},
-    AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-    AllowHeaders:     []string{"Authorization", "Content-Type"},
-    AllowCredentials: true,
-  }))
-    // Зарегистрируем маршруты
-    routes.Register(r, hub)
+	// Запускаем Gin
+	r := gin.Default()
+	originsEnv := os.Getenv("ALLOW_ORIGINS")
+	if originsEnv == "" {
+		originsEnv = "http://localhost:3001"
+	}
+	r.Use(cors.New(cors.Config{
+		AllowOrigins:     strings.Split(originsEnv, ","),
+		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+		AllowHeaders:     []string{"Authorization", "Content-Type"},
+		AllowCredentials: true,
+	}))
+	// Зарегистрируем маршруты
+	routes.Register(r, hub)
 
-    port := os.Getenv("PORT")
-    if port == "" {
-        port = "8080"
-    }
-    log.Printf("chat-service listening on :%s", port)
-    if err := r.Run(":" + port); err != nil {
-        log.Fatalf("failed to run chat-service: %v", err)
-    }
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Printf("chat-service listening on :%s", port)
+	if err := r.Run(":" + port); err != nil {
+		log.Fatalf("failed to run chat-service: %v", err)
+	}
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,13 +20,15 @@ services:
       dockerfile: Dockerfile
       args:
         # совпадает с тем, что слушает Kong (API-gateway)
-        NEXT_PUBLIC_API_URL: http://kong:8000
+        NEXT_PUBLIC_API_URL: http://77.110.98.32:8000
+        NEXT_PUBLIC_WS_URL: ws://77.110.98.32:8000
     image: myorg/frontend:latest
     depends_on:
       - kong
     environment:
       # дублируем на случай, если какие-то пакеты читают её в рантайме
-      - NEXT_PUBLIC_API_URL=http://kong:8000
+      - NEXT_PUBLIC_API_URL=http://77.110.98.32:8000
+      - NEXT_PUBLIC_WS_URL=ws://77.110.98.32:8000
     ports:
       - "3001:3001"       # <-- 3006:3000, чтобы не конфликтовать с другими сервисами
     networks:
@@ -122,6 +124,7 @@ services:
       - CASSANDRA_KEYSPACE=chats
       - JWT_SECRET=verysecret
       - PORT=8080
+      - ALLOW_ORIGINS=http://77.110.98.32:3001
     ports:
       - "3004:8080"
     networks:

--- a/my-next-app/Dockerfile
+++ b/my-next-app/Dockerfile
@@ -11,9 +11,11 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 # Копируем весь исходник
 COPY . .
-# Передаем API_URL, чтобы Next.js вшил его в билд
+# Передаем API_URL и WS_URL, чтобы Next.js вшил их в билд
 ARG NEXT_PUBLIC_API_URL
+ARG NEXT_PUBLIC_WS_URL
 ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+ENV NEXT_PUBLIC_WS_URL=${NEXT_PUBLIC_WS_URL}
 RUN npm run build
 
 # 3) Собираем облегчённый образ для продакшна
@@ -29,6 +31,7 @@ RUN npm ci --production
 
 # Пробрасываем переменную ещё раз, если кто-то читает её в рантайме
 ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
+ENV NEXT_PUBLIC_WS_URL=${NEXT_PUBLIC_WS_URL}
 
-EXPOSE 3000
+EXPOSE 3001
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
## Summary
- adjust `.env` for production IP
- allow custom CORS origins in chat-service
- expose WS URL in frontend build
- update docker-compose to use production API/WS URLs

## Testing
- `go vet ./...`
- `go build ./...`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68628a4200d4832cb6756e056886b39a