### PR TITLE
Fix Caddy start failure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,6 @@
-version: "3.8"
+# The `version` field is deprecated in Compose v2 and newer so we omit it
+# to silence the warning shown on startup.
+# version: "3.8"
 
 services:
   postgres:
@@ -15,6 +17,10 @@ services:
 
   caddy:
     image: caddy:2
+    environment:
+      # Pass DOMAIN into the container so the Caddyfile can expand {$DOMAIN}
+      - DOMAIN=${DOMAIN}
+      - LE_EMAIL=${LE_EMAIL}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - ./caddy_data:/data


### PR DESCRIPTION
## Summary
- avoid deprecated Compose `version` field
- pass DOMAIN and LE_EMAIL into the caddy service so its config can expand

## Testing
- `docker-compose config` *(fails: docker-compose not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6862fb7294ac832cb02d961984199090