### PR TITLE
Fix Caddy ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,9 @@ services:
       # Pass DOMAIN into the container so the Caddyfile can expand {$DOMAIN}
       - DOMAIN=${DOMAIN}
       - LE_EMAIL=${LE_EMAIL}
+      # Configure ports if the defaults 80/443 are unavailable
+      - CADDY_HTTP_PORT=${CADDY_HTTP_PORT}
+      - CADDY_HTTPS_PORT=${CADDY_HTTPS_PORT}
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
       - ./caddy_data:/data


### PR DESCRIPTION
## Summary
- pass CADDY_HTTP_PORT and CADDY_HTTPS_PORT to the Caddy container so it listens on the configured ports

## Testing
- `docker compose version` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68630243d210832c80dc724c2a6a9d13