### PR TITLE
Fix CORS for auth-service

### DIFF
--- a/auth-service/src/main.ts
+++ b/auth-service/src/main.ts
@@ -4,6 +4,12 @@ import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  const origins = process.env.ALLOW_ORIGINS
+    ? process.env.ALLOW_ORIGINS.split(',')
+    : true;
+
+  app.enableCors({ origin: origins, credentials: true });
   
   app.setGlobalPrefix('');  // Kong проксирует «/auth»
   app.useGlobalPipes(new ValidationPipe());

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,8 @@ services:
       DB_PASS: nestpass
       DB_NAME: authdb
       JWT_SECRET: verysecret
+      # Разрешённые домены для CORS
+      ALLOW_ORIGINS: https://${DOMAIN}
     ports:
       - "3000:3000"
     networks:


### PR DESCRIPTION
## Summary
- allow configurable CORS origins for `auth-service`
- set allowed origin via `docker-compose.yml`

## Testing
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6863f13754d4832c8cd05d149dd535c7