### PR TITLE
Fix CORS for user info

### DIFF
--- a/api-gateway/kong.yml
+++ b/api-gateway/kong.yml
@@ -52,9 +52,18 @@ routes:
       - http
 
   - name: users-me
-    service: auth 
+    service: auth
     paths:
       - /users/me
+    strip_path: false
+    protocols:
+      - http
+
+  # Публичная информация о пользователе по ID
+  - name: users-public
+    service: auth
+    paths:
+      - /users/(?<id>[^/]+)
     strip_path: false
     protocols:
       - http


### PR DESCRIPTION
## Summary
- expose `/users/:id` through the gateway so CORS preflight succeeds

## Testing
- `npx --yes next lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686404f91440832c913d79bb1d0d5a9c