### PR TITLE
Fix HTTP redirect with nip.io

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,6 +1,9 @@
 {$DOMAIN} {
+    auto_https off
     reverse_proxy frontend:3001
 }
+
 api.{$DOMAIN} {
+    auto_https off
     reverse_proxy kong:8000
 }

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ This will bootstrap the full stack in the background using the values from
 
  Caddy acts as the reverse proxy and automatically obtains Let's Encrypt certificates for the domain specified in `DOMAIN`. If port 443 is in use, set `CADDY_HTTPS_PORT` in `.env` to an available port (default `444`) and open `https://<DOMAIN>:<CADDY_HTTPS_PORT>` in the browser.
 
+If your `DOMAIN` points to a private address like `127.0.0.1.nip.io`, Let's Encrypt cannot issue a certificate and Caddy's automatic redirect to HTTPS will fail. The included `Caddyfile` disables automatic HTTPS so the stack is reachable over plain HTTP at `http://<DOMAIN>`.
+
 If you see an error like `Bind for 0.0.0.0:80 failed` when starting `caddy`, another service is already using that port. Set `CADDY_HTTP_PORT` in `.env` to an unused port (for example `8080`) and access `http://<DOMAIN>:<CADDY_HTTP_PORT>` instead.
 
 ### Troubleshooting

--- a/api-gateway/kong.yml
+++ b/api-gateway/kong.yml
@@ -108,7 +108,7 @@ plugins:
   - name: cors
     config:
       origins:
-        - https://77.110.98.32.nip.io
+        - http://77.110.98.32.nip.io
       methods:
         - GET
         - POST

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,15 +39,15 @@ services:
       dockerfile: Dockerfile
       args:
         # совпадает с тем, что слушает Kong (API-gateway)
-        NEXT_PUBLIC_API_URL: https://api.${DOMAIN}
-        NEXT_PUBLIC_WS_URL: wss://api.${DOMAIN}
+        NEXT_PUBLIC_API_URL: http://api.${DOMAIN}
+        NEXT_PUBLIC_WS_URL: ws://api.${DOMAIN}
     image: myorg/frontend:latest
     depends_on:
       - kong
     environment:
       # дублируем на случай, если какие-то пакеты читают её в рантайме
-      - NEXT_PUBLIC_API_URL=https://api.${DOMAIN}
-      - NEXT_PUBLIC_WS_URL=wss://api.${DOMAIN}
+      - NEXT_PUBLIC_API_URL=http://api.${DOMAIN}
+      - NEXT_PUBLIC_WS_URL=ws://api.${DOMAIN}
     ports:
       - "3001:3001"       # <-- 3006:3000, чтобы не конфликтовать с другими сервисами
     networks:


### PR DESCRIPTION
## Summary
- disable auto HTTPS in Caddy
- use http/websocket URLs for the frontend
- allow API gateway CORS over HTTP
- document using HTTP when DOMAIN is a private address

## Testing
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866f12a7434832c9fd7d20e7695b3b4