### PR TITLE
Fix WebRTC negotiation

### DIFF
--- a/voice-service/middleware/jwt.go
+++ b/voice-service/middleware/jwt.go
@@ -1,41 +1,41 @@
 package middleware
 
 import (
-    "net/http"
-    "strings"
+	"net/http"
+	"strings"
 
-    "github.com/gin-gonic/gin"
-    "github.com/golang-jwt/jwt/v4"
-    "github.com/yourorg/voice-service/config"
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v4"
+	"github.com/yourorg/voice-service/config"
 )
 
 func JWTAuth() gin.HandlerFunc {
-    return func(c *gin.Context) {
-        // Поддерживаем получение токена из query-параметра
-        tokenStr := c.Query("token")
-        
-        // Если нет в query, проверяем заголовок
-        if tokenStr == "" {
-            auth := c.GetHeader("Authorization")
-            if auth == "" || !strings.HasPrefix(auth, "Bearer ") {
-                c.AbortWithStatus(http.StatusUnauthorized)
-                return
-            }
-            tokenStr = strings.TrimPrefix(auth, "Bearer ")
-        }
+	return func(c *gin.Context) {
+		// Поддерживаем получение токена из query-параметра
+		tokenStr := c.Query("token")
 
-        token, err := jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
-            return []byte(config.JWTSecret), nil
-        })
-        
-        if err != nil || !token.Valid {
-            c.AbortWithStatus(http.StatusUnauthorized)
-            return
-        }
-        
-        claims := token.Claims.(jwt.MapClaims)
-        sub := claims["sub"].(string)
-        c.Set("userId", sub)
-        c.Next()
-    }
+		// Если нет в query, проверяем заголовок
+		if tokenStr == "" {
+			auth := c.GetHeader("Authorization")
+			if auth == "" || !strings.HasPrefix(auth, "Bearer ") {
+				c.AbortWithStatus(http.StatusUnauthorized)
+				return
+			}
+			tokenStr = strings.TrimPrefix(auth, "Bearer ")
+		}
+
+		token, err := jwt.Parse(tokenStr, func(t *jwt.Token) (interface{}, error) {
+			return []byte(config.JWTSecret), nil
+		})
+
+		if err != nil || !token.Valid {
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
+		}
+
+		claims := token.Claims.(jwt.MapClaims)
+		sub := claims["sub"].(string)
+		c.Set("userId", sub)
+		c.Next()
+	}
 }


### PR DESCRIPTION
## Summary
- only generate offers from a designated initiator to avoid double-offer race
- recreate peer connection when using a closed instance
- run gofmt on JWT middleware

## Testing
- `npx prettier my-next-app/src/app/dashboard/page.tsx --write`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867fcfa3fe0832ca290e0ab23523f4c