### PR TITLE
Handle TURN secret credentials

### DIFF
--- a/my-next-app/src/app/api/ice-servers/route.ts
+++ b/my-next-app/src/app/api/ice-servers/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from 'next/server';
+import { createHmac } from 'crypto';
 
 export async function GET() {
   // В реальном приложении используйте переменные окружения!
@@ -9,8 +10,23 @@ export async function GET() {
       ? 'localhost'
       : 'your-production-domain.com');
 
-  const username = process.env.TURN_USERNAME || 'local_user';
-  const credential = process.env.TURN_PASSWORD || 'local_password';
+  // When TURN_SECRET is provided we generate time-limited credentials
+  // following the TURN REST API specification. Username is the expiry
+  // timestamp (current UNIX time + 24h) and credential is the HMAC-SHA1
+  // of this username using the secret.
+  let username: string;
+  let credential: string;
+
+  if (process.env.TURN_SECRET) {
+    const expiry = Math.floor(Date.now() / 1000) + 24 * 3600;
+    username = `${expiry}`;
+    credential = createHmac('sha1', process.env.TURN_SECRET)
+      .update(username)
+      .digest('base64');
+  } else {
+    username = process.env.TURN_USERNAME || 'local_user';
+    credential = process.env.TURN_PASSWORD || 'local_password';
+  }
 
   return NextResponse.json({
     iceServers: [


### PR DESCRIPTION
## Summary
- support TURN REST API using a TURN_SECRET env var
- generate temporary username and HMAC-SHA1 credential when TURN_SECRET is present

## Testing
- `npm run lint` *(fails: numerous existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686805c6be9c832c896bd7c43e051ae2